### PR TITLE
feat: implement command for running the application on systems without electron or GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ npm install
 npm start
 ```
 
+To run it as an ordinary website rather than electron app (might be useful on headless systems):
+instead of `npm start`, execute `npm run start-no-electron`.
+
 ## Testing
 
 Tests are run with the [Jest](https://jestjs.io/) testing framework.

--- a/package.json
+++ b/package.json
@@ -35,8 +35,10 @@
     "clean": "rimraf dist",
     "webpack": "webpack --config ./webpack.config.js",
     "webpack:watch": "webpack --config ./webpack.config.js --watch",
+    "webpack-no-electron": "webpack --config ./webpack.react.js",
     "prestart": "npm run clean",
     "start": "npm run webpack && concurrently --kill-others \"npm run webpack:watch\" \"electron ./dist/main.js\"",
+    "start-no-electron": "npm run clean && npm run webpack-no-electron && npx http-server ./dist",
     "test": "jest"
   },
   "author": "",


### PR DESCRIPTION
I'm not sure how exactly is this project supposed to be used, and how it is used internally in MongoDB.

But I received a link for it as a sample project for the pair programming interview; the interview description seems to assume that it is only used as a sample react project, and that it will only check the frontend knowledge, so presumably Electron knowledge is not going to be needed. And tests do not use electron in any way either.

It seems that, at least in this sample project (again, I have no idea how it's actually used internally), Electron is only used as an unnecessary tool to render a static `index.html` page inside Electron window. But I already have a tool for that on my desktop; it's called "web browser", and it does not require me to have my dev environment with all the node dependencies on the same system.

Running `npm start` on my dev environment predictably results in a bunch of errors like
```
[1] Error loading shared library libgobject-2.0.so.0: No such file or directory (needed by /home/inga/projects/electron-template/node_modules/electron/dist/electron)
[1] Error loading shared library libglib-2.0.so.0: No such file or directory (needed by /home/inga/projects/electron-template/node_modules/electron/dist/electron)
[1] Error loading shared library libgio-2.0.so.0: No such file or directory (needed by /home/inga/projects/electron-template/node_modules/electron/dist/electron)
...
[1] Error relocating /home/inga/projects/electron-template/node_modules/electron/dist/electron: PK11_FreeSlot: symbol not found
[1] Error relocating /home/inga/projects/electron-template/node_modules/electron/dist/electron: CERT_DestroyCertificate: symbol not found
[1] Error relocating /home/inga/projects/electron-template/node_modules/electron/dist/electron: gtk_about_dialog_new: symbol not found
...
[1] Error relocating /home/inga/projects/electron-template/node_modules/electron/dist/electron: g_str_equal: symbol not found
[1] electron ./dist/main.js exited with code 127
--> Sending SIGTERM to other processes..
[0] npm run webpack:watch exited with code SIGTERM
```
(and even if it wouldn't... there is literally no way it would be able to display me an electron window on a system I just ssh'd into.)

So I added a new low-effort npm command that builds an application and serves it as a static react application over HTTP. It works flawlessly in my browser; at least I can click on "Add one" button and see the "count" go up.

Marking this as a draft because I don't know whether this sample project is only used for interviews, or also as a template for actual electron applications. (If it's the latter, then `npm run start-no-electron` probably doesn't belong here; but also then probably it's a good idea to have a separate sample project for interviews, without unnecessarily forcing people to set up an electron dev environment for that.)